### PR TITLE
runtime: fix stack alignment for Windows amd64 lib entry

### DIFF
--- a/src/runtime/rt0_windows_amd64.s
+++ b/src/runtime/rt0_windows_amd64.s
@@ -16,24 +16,12 @@ TEXT _rt0_amd64_windows(SB),NOSPLIT,$-8
 // phase.
 // Leave space for four pointers on the stack as required
 // by the Windows amd64 calling convention.
-TEXT _rt0_amd64_windows_lib(SB),NOSPLIT,$0x48
-	MOVQ	BP, 0x20(SP)
-	MOVQ	BX, 0x28(SP)
-	MOVQ	AX, 0x30(SP)
-	MOVQ  CX, 0x38(SP)
-	MOVQ  DX, 0x40(SP)
-
+TEXT _rt0_amd64_windows_lib(SB),NOSPLIT,$0x20
 	// Create a new thread to do the runtime initialization and return.
 	MOVQ	_cgo_sys_thread_create(SB), AX
 	MOVQ	$_rt0_amd64_windows_lib_go(SB), CX
 	MOVQ	$0, DX
 	CALL	AX
-
-	MOVQ	0x20(SP), BP
-	MOVQ	0x28(SP), BX
-	MOVQ	0x30(SP), AX
-	MOVQ	0x38(SP), CX
-	MOVQ	0x40(SP), DX
 	RET
 
 TEXT _rt0_amd64_windows_lib_go(SB),NOSPLIT,$0


### PR DESCRIPTION
Windows amd64 calling convention requires 16-bytes aligned
stack pointer. Before this patch, the real frame size is
0x48 (frame size) + 0x10 (frame pointer & return address),
which does not satisfy the alignment requirement.

_cgo_sys_thread_create eventually calls NtCreateThread,
which receives a pointer to a ThreadContext structure
allocated from (mis-aligned) stack, and may fail with
STATUS_DATATYPE_MISALIGNMENT on some implementations.

BP is saved/restored by prolog/epilog.
AX, CX, DX are volatile, no need to save and restore.

Fixes #41075

Change-Id: I01c0a22b4bf3b4cfdebf4df587445aa46c667973
GitHub-Last-Rev: 15d2bd740e3e61c9753b3e1b574fdb5da538459c
GitHub-Pull-Request: golang/go#44524
Reviewed-on: https://go-review.googlesource.com/c/go/+/295329
Trust: Alex Brainman <alex.brainman@gmail.com>
Trust: Jason A. Donenfeld <Jason@zx2c4.com>
Run-TryBot: Alex Brainman <alex.brainman@gmail.com>
TryBot-Result: Go Bot <gobot@golang.org>
Reviewed-by: Jason A. Donenfeld <Jason@zx2c4.com>
Reviewed-by: Christopher Nelson <nadiasvertex@gmail.com>

This PR will be imported into Gerrit with the title and first
comment (this text) used to generate the subject and body of
the Gerrit change.

**Please ensure you adhere to every item in this list.**

More info can be found at https://github.com/golang/go/wiki/CommitMessage

+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter
+ No Markdown
+ The first PR comment (this one) is wrapped at 76 characters, unless it's
  really needed (ASCII art, table, or long link)
+ If there is a corresponding issue, add either `Fixes #1234` or `Updates #1234`
  (the latter if this is not a complete fix) to this comment
+ If referring to a repo other than `golang/go` you can use the
  `owner/repo#issue_number` syntax: `Fixes golang/tools#1234`
+ We do not use Signed-off-by lines in Go. Please don't add them.
  Our Gerrit server & GitHub bots enforce CLA compliance instead.
+ Delete these instructions once you have read and applied them
