### PR TITLE
net/netip: fix formatting of IPv4-in-6 address with zone

### DIFF
--- a/src/net/netip/netip.go
+++ b/src/net/netip/netip.go
@@ -769,7 +769,11 @@ func (ip Addr) String() string {
 	default:
 		if ip.Is4In6() {
 			// TODO(bradfitz): this could alloc less.
-			return "::ffff:" + ip.Unmap().String()
+			if z := ip.Zone(); z != "" {
+				return "::ffff:" + ip.Unmap().String() + "%" + z
+			} else {
+				return "::ffff:" + ip.Unmap().String()
+			}
 		}
 		return ip.string6()
 	}
@@ -787,7 +791,12 @@ func (ip Addr) AppendTo(b []byte) []byte {
 	default:
 		if ip.Is4In6() {
 			b = append(b, "::ffff:"...)
-			return ip.Unmap().appendTo4(b)
+			b = ip.Unmap().appendTo4(b)
+			if z := ip.Zone(); z != "" {
+				b = append(b, '%')
+				b = append(b, z...)
+			}
+			return b
 		}
 		return ip.appendTo6(b)
 	}
@@ -947,10 +956,16 @@ func (ip Addr) MarshalText() ([]byte, error) {
 		b := make([]byte, 0, max)
 		if ip.Is4In6() {
 			b = append(b, "::ffff:"...)
-			return ip.Unmap().appendTo4(b), nil
+			b = ip.Unmap().appendTo4(b)
+			if z := ip.Zone(); z != "" {
+				b = append(b, '%')
+				b = append(b, z...)
+			}
+			return b, nil
 		}
 		return ip.appendTo6(b), nil
 	}
+
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.

--- a/src/net/netip/netip_test.go
+++ b/src/net/netip/netip_test.go
@@ -114,6 +114,12 @@ func TestParseAddr(t *testing.T) {
 			ip:  MkAddr(Mk128(0x0001000200000000, 0x0000ffffc0a88cff), intern.Get("eth1")),
 			str: "1:2::ffff:c0a8:8cff%eth1",
 		},
+		// 4-in-6 with zone
+		{
+			in:  "::ffff:192.168.140.255%eth1",
+			ip:  MkAddr(Mk128(0, 0x0000ffffc0a88cff), intern.Get("eth1")),
+			str: "::ffff:192.168.140.255%eth1",
+		},
 		// IPv6 with capital letters.
 		{
 			in:  "FD9E:1A04:F01D::1",


### PR DESCRIPTION
Weird, but don't drop the zone when stringifying.

Fixes #50111

Change-Id: I5fbccdfedcdc77a77ee6bafc8d82b8ec8ec7220c
Reviewed-on: https://go-review.googlesource.com/c/go/+/371094
Run-TryBot: Brad Fitzpatrick <bradfitz@golang.org>
TryBot-Result: Gopher Robot <gobot@golang.org>
Reviewed-by: Matt Layher <mdlayher@gmail.com>
Trust: Matt Layher <mdlayher@gmail.com>
Trust: Ian Lance Taylor <iant@golang.org>

This PR will be imported into Gerrit with the title and first
comment (this text) used to generate the subject and body of
the Gerrit change.

**Please ensure you adhere to every item in this list.**

More info can be found at https://github.com/golang/go/wiki/CommitMessage

+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter
+ No Markdown
+ The first PR comment (this one) is wrapped at 76 characters, unless it's
  really needed (ASCII art, table, or long link)
+ If there is a corresponding issue, add either `Fixes #1234` or `Updates #1234`
  (the latter if this is not a complete fix) to this comment
+ If referring to a repo other than `golang/go` you can use the
  `owner/repo#issue_number` syntax: `Fixes golang/tools#1234`
+ We do not use Signed-off-by lines in Go. Please don't add them.
  Our Gerrit server & GitHub bots enforce CLA compliance instead.
+ Delete these instructions once you have read and applied them
