### PR TITLE
go/types, types2: better error message for invalid == on type parameters

### DIFF
--- a/src/cmd/compile/internal/types2/testdata/fixedbugs/issue48712.go2
+++ b/src/cmd/compile/internal/types2/testdata/fixedbugs/issue48712.go2
@@ -1,0 +1,41 @@
+// Copyright 2022 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package p
+
+func _[P comparable](x, y P) {
+	_ = x == x
+	_ = x == y
+	_ = y == x
+	_ = y == y
+
+	_ = x /* ERROR operator < not defined on P */ < y
+}
+
+func _[P comparable](x P, y any) {
+	_ = x == x
+	_ = x == y
+	_ = y == x
+	_ = y == y
+
+	_ = x /* ERROR operator < not defined on P */ < y
+}
+
+func _[P any](x, y P) {
+	_ = x /* ERROR P is not comparable */ == x
+	_ = x /* ERROR P is not comparable */ == y
+	_ = y /* ERROR P is not comparable */ == x
+	_ = y /* ERROR P is not comparable */ == y
+
+	_ = x /* ERROR operator < not defined on P */ < y
+}
+
+func _[P any](x P, y any) {
+	_ = x /* ERROR P is not comparable */ == x
+	_ = x /* ERROR P is not comparable */ == y
+	_ = y /* ERROR P is not comparable */ == x
+	_ = y == y
+
+	_ = x /* ERROR operator < not defined on P */ < y
+}

--- a/src/go/types/expr.go
+++ b/src/go/types/expr.go
@@ -729,10 +729,12 @@ func (check *Checker) comparison(x, y *operand, op token.Token) {
 	xok, _ := x.assignableTo(check, y.typ, nil)
 	yok, _ := y.assignableTo(check, x.typ, nil)
 	if xok || yok {
+		equality := false
 		defined := false
 		switch op {
 		case token.EQL, token.NEQ:
 			// spec: "The equality operators == and != apply to operands that are comparable."
+			equality = true
 			defined = Comparable(x.typ) && Comparable(y.typ) || x.isNil() && hasNil(y.typ) || y.isNil() && hasNil(x.typ)
 		case token.LSS, token.LEQ, token.GTR, token.GEQ:
 			// spec: The ordering operators <, <=, >, and >= apply to operands that are ordered."
@@ -741,11 +743,19 @@ func (check *Checker) comparison(x, y *operand, op token.Token) {
 			unreachable()
 		}
 		if !defined {
-			typ := x.typ
-			if x.isNil() {
-				typ = y.typ
+			if equality && (isTypeParam(x.typ) || isTypeParam(y.typ)) {
+				typ := x.typ
+				if isTypeParam(y.typ) {
+					typ = y.typ
+				}
+				err = check.sprintf("%s is not comparable", typ)
+			} else {
+				typ := x.typ
+				if x.isNil() {
+					typ = y.typ
+				}
+				err = check.sprintf("operator %s not defined on %s", op, typ)
 			}
-			err = check.sprintf("operator %s not defined on %s", op, typ)
 			code = _UndefinedOp
 		}
 	} else {

--- a/src/go/types/testdata/fixedbugs/issue48712.go2
+++ b/src/go/types/testdata/fixedbugs/issue48712.go2
@@ -1,0 +1,41 @@
+// Copyright 2022 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package p
+
+func _[P comparable](x, y P) {
+	_ = x == x
+	_ = x == y
+	_ = y == x
+	_ = y == y
+
+	_ = x /* ERROR operator < not defined on P */ < y
+}
+
+func _[P comparable](x P, y any) {
+	_ = x == x
+	_ = x == y
+	_ = y == x
+	_ = y == y
+
+	_ = x /* ERROR operator < not defined on P */ < y
+}
+
+func _[P any](x, y P) {
+	_ = x /* ERROR P is not comparable */ == x
+	_ = x /* ERROR P is not comparable */ == y
+	_ = y /* ERROR P is not comparable */ == x
+	_ = y /* ERROR P is not comparable */ == y
+
+	_ = x /* ERROR operator < not defined on P */ < y
+}
+
+func _[P any](x P, y any) {
+	_ = x /* ERROR P is not comparable */ == x
+	_ = x /* ERROR P is not comparable */ == y
+	_ = y /* ERROR P is not comparable */ == x
+	_ = y == y
+
+	_ = x /* ERROR operator < not defined on P */ < y
+}


### PR DESCRIPTION
Fixes #48712.

Change-Id: I6f214cdfdd1815493f2a04828e8f0097f1d8c124
Reviewed-on: https://go-review.googlesource.com/c/go/+/372734
Trust: Robert Griesemer <gri@golang.org>
Run-TryBot: Robert Griesemer <gri@golang.org>
TryBot-Result: Gopher Robot <gobot@golang.org>
Reviewed-by: Robert Findley <rfindley@google.com>

This PR will be imported into Gerrit with the title and first
comment (this text) used to generate the subject and body of
the Gerrit change.

**Please ensure you adhere to every item in this list.**

More info can be found at https://github.com/golang/go/wiki/CommitMessage

+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter
+ No Markdown
+ The first PR comment (this one) is wrapped at 76 characters, unless it's
  really needed (ASCII art, table, or long link)
+ If there is a corresponding issue, add either `Fixes #1234` or `Updates #1234`
  (the latter if this is not a complete fix) to this comment
+ If referring to a repo other than `golang/go` you can use the
  `owner/repo#issue_number` syntax: `Fixes golang/tools#1234`
+ We do not use Signed-off-by lines in Go. Please don't add them.
  Our Gerrit server & GitHub bots enforce CLA compliance instead.
+ Delete these instructions once you have read and applied them
