### PR TITLE
cmd/internal/obj/arm64: adjust rule for VMOVQ instruction

### DIFF
--- a/src/cmd/internal/obj/arm64/asm7.go
+++ b/src/cmd/internal/obj/arm64/asm7.go
@@ -1184,7 +1184,7 @@ func (c *ctxt7) addpool128(p *obj.Prog, al, ah *obj.Addr) {
 	q := c.newprog()
 	q.As = ADWORD
 	q.To.Type = obj.TYPE_CONST
-	q.To.Offset = al.Offset
+	q.To.Offset = al.Offset // q.Pc is lower than t.Pc, so al.Offset is stored in q.
 
 	t := c.newprog()
 	t.As = ADWORD

--- a/src/cmd/internal/obj/arm64/doc.go
+++ b/src/cmd/internal/obj/arm64/doc.go
@@ -89,12 +89,12 @@ In the following example, PCALIGN at the entry of the function Add will align it
 7. Move large constants to vector registers.
 
 Go asm uses VMOVQ/VMOVD/VMOVS to move 128-bit, 64-bit and 32-bit constants into vector registers, respectively.
-And for a 128-bit interger, it take two 64-bit operands, for the high and low parts separately.
+And for a 128-bit interger, it take two 64-bit operands, for the low and high parts separately.
 
   Examples:
     VMOVS $0x11223344, V0
     VMOVD $0x1122334455667788, V1
-    VMOVQ $0x1122334455667788, $8877665544332211, V2   // V2=0x11223344556677888877665544332211
+    VMOVQ $0x1122334455667788, $0x99aabbccddeeff00, V2   // V2=0x99aabbccddeeff001122334455667788
 
 8. Move an optionally-shifted 16-bit immediate value to a register.
 


### PR DESCRIPTION
The VMOVQ instruction stores a 128-bit number into a V register, for
example:
    VMOVQ $0x1122334455667788, $0x99aabbccddeeff00, V2
From a documentation (https://pkg.go.dev/cmd/internal/obj/arm64) point
of view, the value in V2 should be 0x112233445566778899aabbccddeeff00,
however the value is actually 0x99aabbccddeeff001122334455667788. The
reason is that we misplaced the high 64-bit and the low 64-bit in the
literal pool. To maintain backward compatibility, this CL adjusts the
rule of VMOVQ instruction to make the documentation consistent with the
code.

Fixes #50528

Change-Id: Ib51f59e97c55252ab2a50bbc6ba4d430732a7a04
Reviewed-on: https://go-review.googlesource.com/c/go/+/377055
Reviewed-by: Cherry Mui <cherryyz@google.com>
Reviewed-by: Eric Fang <eric.fang@arm.com>
Run-TryBot: Eric Fang <eric.fang@arm.com>
Trust: Eric Fang <eric.fang@arm.com>
TryBot-Result: Gopher Robot <gobot@golang.org>

This PR will be imported into Gerrit with the title and first
comment (this text) used to generate the subject and body of
the Gerrit change.

**Please ensure you adhere to every item in this list.**

More info can be found at https://github.com/golang/go/wiki/CommitMessage

+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter
+ No Markdown
+ The first PR comment (this one) is wrapped at 76 characters, unless it's
  really needed (ASCII art, table, or long link)
+ If there is a corresponding issue, add either `Fixes #1234` or `Updates #1234`
  (the latter if this is not a complete fix) to this comment
+ If referring to a repo other than `golang/go` you can use the
  `owner/repo#issue_number` syntax: `Fixes golang/tools#1234`
+ We do not use Signed-off-by lines in Go. Please don't add them.
  Our Gerrit server & GitHub bots enforce CLA compliance instead.
+ Delete these instructions once you have read and applied them
