### PR TITLE
mime: ignore .js => text/plain in Windows registry

### DIFF
--- a/doc/go1.19.html
+++ b/doc/go1.19.html
@@ -216,6 +216,22 @@ Do not send CLs removing the interior tags from such phrases.
   </dd>
 </dl><!-- io -->
 
+<dl id="mime"><dt><a href="/pkg/mime/">mime</a></dt>
+  <dd>
+    <p><!-- CL 406894 -->
+      On Windows only, the mime package now ignores a registry entry
+      recording that the extension <code>.js</code> should have MIME
+      type <code>text/plain</code>. This is a common unintentional
+      misconfiguration on Windows systems. The effect is
+      that <code>.js</code> will have the default MIME
+      type <code>text/javascript; charset=utf-8</code>.
+      Applications that expect <code>text/plain</code> on Windows must
+      now explicitly call
+      <a href="/pkg/mime#AddExtensionType"><code>AddExtensionType</code></a>.
+    </p>
+  </dd>
+</dl>
+
 <dl id="net"><dt><a href="/pkg/net/">net</a></dt>
   <dd>
     <p><!-- CL 386016 -->

--- a/src/mime/type_windows.go
+++ b/src/mime/type_windows.go
@@ -30,6 +30,17 @@ func initMimeWindows() {
 		if err != nil {
 			continue
 		}
+
+		// There is a long-standing problem on Windows: the
+		// registry sometimes records that the ".js" extension
+		// should be "text/plain". See issue #32350. While
+		// normally local configuration should override
+		// defaults, this problem is common enough that we
+		// handle it here by ignoring that registry setting.
+		if name == ".js" && (v == "text/plain" || v == "text/plain; charset=utf-8") {
+			continue
+		}
+
 		setExtensionType(name, v)
 	}
 }


### PR DESCRIPTION
This seems to be a common registry misconfiguration on Windows.

Fixes #32350

Change-Id: I68c617c42a6e72948e2acdf335ff8e7df569432d
Reviewed-on: https://go-review.googlesource.com/c/go/+/406894
Reviewed-by: Michael Knyszek <mknyszek@google.com>
TryBot-Result: Gopher Robot <gobot@golang.org>
Run-TryBot: Ian Lance Taylor <iant@golang.org>
Reviewed-by: Damien Neil <dneil@google.com>

This PR will be imported into Gerrit with the title and first
comment (this text) used to generate the subject and body of
the Gerrit change.

**Please ensure you adhere to every item in this list.**

More info can be found at https://github.com/golang/go/wiki/CommitMessage

+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter
+ No Markdown
+ The first PR comment (this one) is wrapped at 76 characters, unless it's
  really needed (ASCII art, table, or long link)
+ If there is a corresponding issue, add either `Fixes #1234` or `Updates #1234`
  (the latter if this is not a complete fix) to this comment
+ If referring to a repo other than `golang/go` you can use the
  `owner/repo#issue_number` syntax: `Fixes golang/tools#1234`
+ We do not use Signed-off-by lines in Go. Please don't add them.
  Our Gerrit server & GitHub bots enforce CLA compliance instead.
+ Delete these instructions once you have read and applied them
