### PR TITLE
doc/go1.19: fix HTML validation issues

### DIFF
--- a/doc/go1.19.html
+++ b/doc/go1.19.html
@@ -741,7 +741,7 @@ as well as support for rendering them to HTML, Markdown, and text.
   </dd>
 </dl><!-- regexp -->
 
-<dl id="runtime"><dt><a href="/pkg/runtime/">runtime</a></dt>
+<dl id="pkg-runtime"><dt><a href="/pkg/runtime/">runtime</a></dt>
   <dd>
     <p><!-- https://go.dev/issue/51461 -->
       The <a href="/pkg/runtime/#GOROOT"><code>GOROOT</code></a> function now returns the empty string
@@ -846,7 +846,6 @@ as well as support for rendering them to HTML, Markdown, and text.
       <a href="/pkg/sort/#Search">Search</a>
       but often easier to use: it returns an additional boolean reporting whether an equal value was found.
     </p>
-  </dd>
   </dd>
 </dl><!-- sort -->
 


### PR DESCRIPTION
Avoid duplicating tag ID runtime and remove a superflous </dd> tag.

Found by https://validator.w3.org

Change-Id: I9c84b8257acbb6d3d6817192bb8d355207944b9a
Reviewed-on: https://go-review.googlesource.com/c/go/+/413254
Auto-Submit: Ian Lance Taylor <iant@google.com>
Reviewed-by: Ian Lance Taylor <iant@google.com>
TryBot-Result: Gopher Robot <gobot@golang.org>
Reviewed-by: Dmitri Shuralyov <dmitshur@google.com>
Run-TryBot: Ian Lance Taylor <iant@google.com>

This PR will be imported into Gerrit with the title and first
comment (this text) used to generate the subject and body of
the Gerrit change.

**Please ensure you adhere to every item in this list.**

More info can be found at https://github.com/golang/go/wiki/CommitMessage

+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter
+ No Markdown
+ The first PR comment (this one) is wrapped at 76 characters, unless it's
  really needed (ASCII art, table, or long link)
+ If there is a corresponding issue, add either `Fixes #1234` or `Updates #1234`
  (the latter if this is not a complete fix) to this comment
+ If referring to a repo other than `golang/go` you can use the
  `owner/repo#issue_number` syntax: `Fixes golang/tools#1234`
+ We do not use Signed-off-by lines in Go. Please don't add them.
  Our Gerrit server & GitHub bots enforce CLA compliance instead.
+ Delete these instructions once you have read and applied them
