### PR TITLE
misc/cgo/testsanitizers: add libfuzzer tests

### DIFF
--- a/misc/cgo/testsanitizers/libfuzzer_test.go
+++ b/misc/cgo/testsanitizers/libfuzzer_test.go
@@ -1,0 +1,90 @@
+// Copyright 2022 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package sanitizers_test
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestLibFuzzer(t *testing.T) {
+	goos, err := goEnv("GOOS")
+	if err != nil {
+		t.Fatal(err)
+	}
+	goarch, err := goEnv("GOARCH")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !libFuzzerSupported(goos, goarch) {
+		t.Skipf("skipping on %s/%s; libfuzzer option is not supported.", goos, goarch)
+	}
+	config := configure("fuzzer")
+	config.skipIfCSanitizerBroken(t)
+
+	cases := []struct {
+		goSrc         string
+		cSrc          string
+		expectedError string
+	}{
+		{goSrc: "libfuzzer1.go", expectedError: "panic: found it"},
+		{goSrc: "libfuzzer2.go", cSrc: "libfuzzer2.c", expectedError: "panic: found it"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		name := strings.TrimSuffix(tc.goSrc, ".go")
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			dir := newTempDir(t)
+			defer dir.RemoveAll(t)
+
+			// build Go code in libfuzzer mode to a c-archive
+			outPath := dir.Join(name)
+			archivePath := dir.Join(name + ".a")
+			mustRun(t, config.goCmd("build", "-buildmode=c-archive", "-o", archivePath, srcPath(tc.goSrc)))
+
+			// build C code (if any) and link with Go code
+			cmd, err := cc(config.cFlags...)
+			if err != nil {
+				t.Fatalf("error running cc: %v", err)
+			}
+			cmd.Args = append(cmd.Args, config.ldFlags...)
+			cmd.Args = append(cmd.Args, "-o", outPath, "-I", dir.Base())
+			if tc.cSrc != "" {
+				cmd.Args = append(cmd.Args, srcPath(tc.cSrc))
+			}
+			cmd.Args = append(cmd.Args, archivePath)
+			mustRun(t, cmd)
+
+			cmd = hangProneCmd(outPath)
+			outb, err := cmd.CombinedOutput()
+			out := string(outb)
+			if err == nil {
+				t.Fatalf("fuzzing succeeded unexpectedly; output:\n%s", out)
+			}
+			if !strings.Contains(out, tc.expectedError) {
+				t.Errorf("exited without expected error %q; got\n%s", tc.expectedError, out)
+			}
+		})
+	}
+}
+
+// libFuzzerSupported is a copy of the function internal/platform.FuzzInstrumented,
+// because the internal package can't be used here.
+func libFuzzerSupported(goos, goarch string) bool {
+	switch goarch {
+	case "amd64", "arm64":
+		// TODO(#14565): support more architectures.
+		switch goos {
+		case "darwin", "freebsd", "linux", "windows":
+			return true
+		default:
+			return false
+		}
+	default:
+		return false
+	}
+}

--- a/misc/cgo/testsanitizers/testdata/libfuzzer1.go
+++ b/misc/cgo/testsanitizers/testdata/libfuzzer1.go
@@ -1,0 +1,16 @@
+package main
+
+import "C"
+
+import "unsafe"
+
+//export LLVMFuzzerTestOneInput
+func LLVMFuzzerTestOneInput(p unsafe.Pointer, sz C.int) C.int {
+	b := C.GoBytes(p, sz)
+	if len(b) >= 6 && b[0] == 'F' && b[1] == 'u' && b[2] == 'z' && b[3] == 'z' && b[4] == 'M' && b[5] == 'e' {
+		panic("found it")
+	}
+	return 0
+}
+
+func main() {}

--- a/misc/cgo/testsanitizers/testdata/libfuzzer2.c
+++ b/misc/cgo/testsanitizers/testdata/libfuzzer2.c
@@ -1,0 +1,11 @@
+#include <stddef.h>
+
+#include "libfuzzer2.h"
+
+int LLVMFuzzerTestOneInput(char *data, size_t size) {
+ 	if (size > 0 && data[0] == 'H')
+		if (size > 1 && data[1] == 'I')
+			if (size > 2 && data[2] == '!')
+				FuzzMe(data, size);
+	return 0;
+}

--- a/misc/cgo/testsanitizers/testdata/libfuzzer2.go
+++ b/misc/cgo/testsanitizers/testdata/libfuzzer2.go
@@ -1,0 +1,16 @@
+package main
+
+import "C"
+
+import "unsafe"
+
+//export FuzzMe
+func FuzzMe(p unsafe.Pointer, sz C.int) {
+	b := C.GoBytes(p, sz)
+	b = b[3:]
+	if len(b) >= 4 && b[0] == 'f' && b[1] == 'u' && b[2] == 'z' && b[3] == 'z' {
+		panic("found it")
+	}
+}
+
+func main() {}


### PR DESCRIPTION
Apparently we don't have tests for libfuzzer mode. Add some tests.

Updates #57449.

Change-Id: I813da3e71c6d6f15db31914b248db220b0b7041e
Reviewed-on: https://go-review.googlesource.com/c/go/+/459555
TryBot-Result: Gopher Robot <gobot@golang.org>
Reviewed-by: Than McIntosh <thanm@google.com>
Run-TryBot: Cherry Mui <cherryyz@google.com>

This PR will be imported into Gerrit with the title and first
comment (this text) used to generate the subject and body of
the Gerrit change.

**Please ensure you adhere to every item in this list.**

More info can be found at https://github.com/golang/go/wiki/CommitMessage

+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter
+ No Markdown
+ The first PR comment (this one) is wrapped at 76 characters, unless it's
  really needed (ASCII art, table, or long link)
+ If there is a corresponding issue, add either `Fixes #1234` or `Updates #1234`
  (the latter if this is not a complete fix) to this comment
+ If referring to a repo other than `golang/go` you can use the
  `owner/repo#issue_number` syntax: `Fixes golang/tools#1234`
+ We do not use Signed-off-by lines in Go. Please don't add them.
  Our Gerrit server & GitHub bots enforce CLA compliance instead.
+ Delete these instructions once you have read and applied them
