### PR TITLE
runtime: check GOFLAGS not GCFLAGS

### DIFF
--- a/src/runtime/crash_unix_test.go
+++ b/src/runtime/crash_unix_test.go
@@ -76,7 +76,7 @@ func TestCrashDumpsAllThreads(t *testing.T) {
 
 	testenv.MustHaveGoBuild(t)
 
-	if strings.Contains(os.Getenv("GCFLAGS"), "mayMoreStackPreempt") {
+	if strings.Contains(os.Getenv("GOFLAGS"), "mayMoreStackPreempt") {
 		// This test occasionally times out in this debug mode. This is probably
 		// revealing a real bug in the scheduler, but since it seems to only
 		// affect this test and this is itself a test of a debug mode, it's not


### PR DESCRIPTION
GCFLAGS doesn't have any defined meaning. cmd/dist enables mayMoreStackPreempt with GOFLAGS.

For #55160.

Change-Id: I7ac71e4a1a983a56bd228ab5d24294db5cc595f7
Reviewed-on: https://go-review.googlesource.com/c/go/+/507359
Run-TryBot: Michael Pratt <mpratt@google.com>
TryBot-Result: Gopher Robot <gobot@golang.org>
Reviewed-by: Michael Knyszek <mknyszek@google.com>
Auto-Submit: Michael Pratt <mpratt@google.com>

This PR will be imported into Gerrit with the title and first
comment (this text) used to generate the subject and body of
the Gerrit change.

**Please ensure you adhere to every item in this list.**

More info can be found at https://github.com/golang/go/wiki/CommitMessage

+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter
+ No Markdown
+ The first PR comment (this one) is wrapped at 76 characters, unless it's
  really needed (ASCII art, table, or long link)
+ If there is a corresponding issue, add either `Fixes #1234` or `Updates #1234`
  (the latter if this is not a complete fix) to this comment
+ If referring to a repo other than `golang/go` you can use the
  `owner/repo#issue_number` syntax: `Fixes golang/tools#1234`
+ We do not use Signed-off-by lines in Go. Please don't add them.
  Our Gerrit server & GitHub bots enforce CLA compliance instead.
+ Delete these instructions once you have read and applied them
