### PR TITLE
runtime: fix badmorestackg0 never called on wasm

### DIFF
--- a/src/runtime/asm_wasm.s
+++ b/src/runtime/asm_wasm.s
@@ -223,7 +223,7 @@ TEXT runtime·morestack(SB), NOSPLIT, $0-0
 
 	// Cannot grow scheduler stack (m->g0).
 	Get g
-	Get R1
+	Get R2
 	I64Eq
 	If
 		CALLNORESUME runtime·badmorestackg0(SB)


### PR DESCRIPTION
Previously, badmorestackg0 was never called since it was behind a g == R1 check, R1 holding g.m. This is clearly wrong, since we want to check if g == g0. Fixed by using R2 that holds the value of g0.

Fixes #63953

Change-Id: I1e2a1c3be7ad9e7ae8dbf706ef6783e664a44764
GitHub-Last-Rev: b3e92cf28603ef6f6fafc9f9b724b84253a4355c
GitHub-Pull-Request: golang/go#63954
Reviewed-on: https://go-review.googlesource.com/c/go/+/539840
Reviewed-by: Austin Clements <austin@google.com>
Auto-Submit: Austin Clements <austin@google.com>
LUCI-TryBot-Result: Go LUCI <golang-scoped@luci-project-accounts.iam.gserviceaccount.com>
Reviewed-by: Michael Knyszek <mknyszek@google.com>

This PR will be imported into Gerrit with the title and first
comment (this text) used to generate the subject and body of
the Gerrit change.

**Please ensure you adhere to every item in this list.**

More info can be found at https://github.com/golang/go/wiki/CommitMessage

+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter
+ No Markdown
+ The first PR comment (this one) is wrapped at 76 characters, unless it's
  really needed (ASCII art, table, or long link)
+ If there is a corresponding issue, add either `Fixes #1234` or `Updates #1234`
  (the latter if this is not a complete fix) to this comment
+ If referring to a repo other than `golang/go` you can use the
  `owner/repo#issue_number` syntax: `Fixes golang/tools#1234`
+ We do not use Signed-off-by lines in Go. Please don't add them.
  Our Gerrit server & GitHub bots enforce CLA compliance instead.
+ Delete these instructions once you have read and applied them
