### PR TITLE
runtime: mark lockWithRankMayAcquire as nosplit

### DIFF
--- a/src/runtime/lockrank_off.go
+++ b/src/runtime/lockrank_off.go
@@ -42,6 +42,9 @@ func releaseLockRankAndM(rank lockRank) {
 	releasem(getg().m)
 }
 
+// This function may be called in nosplit context and thus must be nosplit.
+//
+//go:nosplit
 func lockWithRankMayAcquire(l *mutex, rank lockRank) {
 }
 

--- a/test/fixedbugs/issue68525.go
+++ b/test/fixedbugs/issue68525.go
@@ -1,0 +1,13 @@
+// run -gcflags='all=-N -l'
+
+// Copyright 2024 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+import "os"
+
+func main() {
+	os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+}


### PR DESCRIPTION
The function is called in nosplit context already.

Fixes #68525

Change-Id: I8b9e324335b7c605d5a20cacdd58df09b7a7cf52
Reviewed-on: https://go-review.googlesource.com/c/go/+/599675
Reviewed-by: Cherry Mui <cherryyz@google.com>
Reviewed-by: Michael Knyszek <mknyszek@google.com>
LUCI-TryBot-Result: Go LUCI <golang-scoped@luci-project-accounts.iam.gserviceaccount.com>
Auto-Submit: Cuong Manh Le <cuong.manhle.vn@gmail.com>

This PR will be imported into Gerrit with the title and first
comment (this text) used to generate the subject and body of
the Gerrit change.

**Please ensure you adhere to every item in this list.**

More info can be found at https://github.com/golang/go/wiki/CommitMessage

+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter
+ No Markdown
+ The first PR comment (this one) is wrapped at 76 characters, unless it's
  really needed (ASCII art, table, or long link)
+ If there is a corresponding issue, add either `Fixes #1234` or `Updates #1234`
  (the latter if this is not a complete fix) to this comment
+ If referring to a repo other than `golang/go` you can use the
  `owner/repo#issue_number` syntax: `Fixes golang/tools#1234`
+ We do not use Signed-off-by lines in Go. Please don't add them.
  Our Gerrit server & GitHub bots enforce CLA compliance instead.
+ Delete these instructions once you have read and applied them
