### PR TITLE
cmd/link: check if the trampoline is actually added

### DIFF
--- a/src/cmd/link/link_test.go
+++ b/src/cmd/link/link_test.go
@@ -706,6 +706,14 @@ func TestTrampoline(t *testing.T) {
 		if string(out) != "hello\n" {
 			t.Errorf("unexpected output (%s):\n%s", mode, out)
 		}
+
+		out, err = testenv.Command(t, testenv.GoToolPath(t), "tool", "nm", exe).CombinedOutput()
+		if err != nil {
+			t.Errorf("nm failure: %s\n%s\n", err, string(out))
+		}
+		if !bytes.Contains(out, []byte("T runtime.deferreturn+0-tramp0")) {
+			t.Errorf("Trampoline T runtime.deferreturn+0-tramp0 is missing")
+		}
 	}
 }
 


### PR DESCRIPTION
Change-Id: I2ddffe9118fd9954d9bae60c92fd8fc5b311b93a
Reviewed-on: https://go-review.googlesource.com/c/go/+/603736
Reviewed-by: Michael Pratt <mpratt@google.com>
LUCI-TryBot-Result: Go LUCI <golang-scoped@luci-project-accounts.iam.gserviceaccount.com>
Reviewed-by: Cherry Mui <cherryyz@google.com>
Reviewed-by: abner chenc <chenguoqi@loongson.cn>

This PR will be imported into Gerrit with the title and first
comment (this text) used to generate the subject and body of
the Gerrit change.

**Please ensure you adhere to every item in this list.**

More info can be found at https://github.com/golang/go/wiki/CommitMessage

+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter
+ No Markdown
+ The first PR comment (this one) is wrapped at 76 characters, unless it's
  really needed (ASCII art, table, or long link)
+ If there is a corresponding issue, add either `Fixes #1234` or `Updates #1234`
  (the latter if this is not a complete fix) to this comment
+ If referring to a repo other than `golang/go` you can use the
  `owner/repo#issue_number` syntax: `Fixes golang/tools#1234`
+ We do not use Signed-off-by lines in Go. Please don't add them.
  Our Gerrit server & GitHub bots enforce CLA compliance instead.
+ Delete these instructions once you have read and applied them
