### PR TITLE
crypto/mlkem: swap order of return values of Encapsulate

### DIFF
--- a/src/crypto/internal/fips140/mlkem/cast.go
+++ b/src/crypto/internal/fips140/mlkem/cast.go
@@ -40,7 +40,7 @@ func init() {
 		dk := &DecapsulationKey768{}
 		kemKeyGen(dk, d, z)
 		ek := dk.EncapsulationKey()
-		c, Ke := ek.EncapsulateInternal(m)
+		Ke, c := ek.EncapsulateInternal(m)
 		Kd, err := dk.Decapsulate(c)
 		if err != nil {
 			return err

--- a/src/crypto/mlkem/mlkem1024.go
+++ b/src/crypto/mlkem/mlkem1024.go
@@ -91,6 +91,6 @@ func (ek *EncapsulationKey1024) Bytes() []byte {
 // encapsulation key, drawing random bytes from crypto/rand.
 //
 // The shared key must be kept secret.
-func (ek *EncapsulationKey1024) Encapsulate() (ciphertext, sharedKey []byte) {
+func (ek *EncapsulationKey1024) Encapsulate() (sharedKey, ciphertext []byte) {
 	return ek.key.Encapsulate()
 }

--- a/src/crypto/mlkem/mlkem768.go
+++ b/src/crypto/mlkem/mlkem768.go
@@ -101,6 +101,6 @@ func (ek *EncapsulationKey768) Bytes() []byte {
 // encapsulation key, drawing random bytes from crypto/rand.
 //
 // The shared key must be kept secret.
-func (ek *EncapsulationKey768) Encapsulate() (ciphertext, sharedKey []byte) {
+func (ek *EncapsulationKey768) Encapsulate() (sharedKey, ciphertext []byte) {
 	return ek.key.Encapsulate()
 }

--- a/src/crypto/mlkem/mlkem_test.go
+++ b/src/crypto/mlkem/mlkem_test.go
@@ -43,7 +43,7 @@ func testRoundTrip[E encapsulationKey, D decapsulationKey[E]](
 		t.Fatal(err)
 	}
 	ek := dk.EncapsulationKey()
-	c, Ke := ek.Encapsulate()
+	Ke, c := ek.Encapsulate()
 	Kd, err := dk.Decapsulate(c)
 	if err != nil {
 		t.Fatal(err)
@@ -66,7 +66,7 @@ func testRoundTrip[E encapsulationKey, D decapsulationKey[E]](
 	if !bytes.Equal(dk.Bytes(), dk1.Bytes()) {
 		t.Fail()
 	}
-	c1, Ke1 := ek1.Encapsulate()
+	Ke1, c1 := ek1.Encapsulate()
 	Kd1, err := dk1.Decapsulate(c1)
 	if err != nil {
 		t.Fatal(err)
@@ -86,7 +86,7 @@ func testRoundTrip[E encapsulationKey, D decapsulationKey[E]](
 		t.Fail()
 	}
 
-	c2, Ke2 := dk.EncapsulationKey().Encapsulate()
+	Ke2, c2 := dk.EncapsulationKey().Encapsulate()
 	if bytes.Equal(c, c2) {
 		t.Fail()
 	}
@@ -115,7 +115,7 @@ func testBadLengths[E encapsulationKey, D decapsulationKey[E]](
 	}
 	ek := dk.EncapsulationKey()
 	ekBytes := dk.EncapsulationKey().Bytes()
-	c, _ := ek.Encapsulate()
+	_, c := ek.Encapsulate()
 
 	for i := 0; i < len(dkBytes)-1; i++ {
 		if _, err := newDecapsulationKey(dkBytes[:i]); err == nil {
@@ -189,7 +189,7 @@ func TestAccumulated(t *testing.T) {
 		o.Write(ek.Bytes())
 
 		s.Read(msg[:])
-		ct, k := ek.key.EncapsulateInternal(&msg)
+		k, ct := ek.key.EncapsulateInternal(&msg)
 		o.Write(ct)
 		o.Write(k)
 
@@ -244,7 +244,7 @@ func BenchmarkEncaps(b *testing.B) {
 		if err != nil {
 			b.Fatal(err)
 		}
-		c, K := ek.key.EncapsulateInternal(&m)
+		K, c := ek.key.EncapsulateInternal(&m)
 		sink ^= c[0] ^ K[0]
 	}
 }
@@ -255,7 +255,7 @@ func BenchmarkDecaps(b *testing.B) {
 		b.Fatal(err)
 	}
 	ek := dk.EncapsulationKey()
-	c, _ := ek.Encapsulate()
+	_, c := ek.Encapsulate()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		K, _ := dk.Decapsulate(c)
@@ -270,7 +270,7 @@ func BenchmarkRoundTrip(b *testing.B) {
 	}
 	ek := dk.EncapsulationKey()
 	ekBytes := ek.Bytes()
-	c, _ := ek.Encapsulate()
+	_, c := ek.Encapsulate()
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -296,7 +296,7 @@ func BenchmarkRoundTrip(b *testing.B) {
 			if err != nil {
 				b.Fatal(err)
 			}
-			cS, Ks := ek.Encapsulate()
+			Ks, cS := ek.Encapsulate()
 			if err != nil {
 				b.Fatal(err)
 			}

--- a/src/crypto/tls/handshake_server_tls13.go
+++ b/src/crypto/tls/handshake_server_tls13.go
@@ -280,7 +280,7 @@ func (hs *serverHandshakeStateTLS13) processClientHello() error {
 			c.sendAlert(alertIllegalParameter)
 			return errors.New("tls: invalid X25519MLKEM768 client key share")
 		}
-		ciphertext, mlkemSharedSecret := k.Encapsulate()
+		mlkemSharedSecret, ciphertext := k.Encapsulate()
 		// draft-kwiatkowski-tls-ecdhe-mlkem-02, Section 3.1.3: "For
 		// X25519MLKEM768, the shared secret is the concatenation of the ML-KEM
 		// shared secret and the X25519 shared secret. The shared secret is 64


### PR DESCRIPTION
Per FIPS 203 (https://csrc.nist.gov/pubs/fips/203/final), the order of return values should be sharedKey, ciphertext. This commit simply swaps those return values and updates any consumers of the Encapsulate() method to respect the new order.

Fixes #70950

Change-Id: I2a0d605e3baf7fe69510d60d3d35bbac18f883c9
Reviewed-on: https://go-review.googlesource.com/c/go/+/638376
LUCI-TryBot-Result: Go LUCI <golang-scoped@luci-project-accounts.iam.gserviceaccount.com>
Reviewed-by: Austin Clements <austin@google.com>
Auto-Submit: Ian Lance Taylor <iant@golang.org>
Reviewed-by: Filippo Valsorda <filippo@golang.org>
Reviewed-by: Cherry Mui <cherryyz@google.com>

This PR will be imported into Gerrit with the title and first
comment (this text) used to generate the subject and body of
the Gerrit change.

**Please ensure you adhere to every item in this list.**

More info can be found at https://github.com/golang/go/wiki/CommitMessage

+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter
+ No Markdown
+ The first PR comment (this one) is wrapped at 76 characters, unless it's
  really needed (ASCII art, table, or long link)
+ If there is a corresponding issue, add either `Fixes #1234` or `Updates #1234`
  (the latter if this is not a complete fix) to this comment
+ If referring to a repo other than `golang/go` you can use the
  `owner/repo#issue_number` syntax: `Fixes golang/tools#1234`
+ We do not use Signed-off-by lines in Go. Please don't add them.
  Our Gerrit server & GitHub bots enforce CLA compliance instead.
+ Delete these instructions once you have read and applied them
