### PR TITLE
simd/archsimd: skip tests if AVX is not available

### DIFF
--- a/src/simd/archsimd/internal/simd_test/simd_test.go
+++ b/src/simd/archsimd/internal/simd_test/simd_test.go
@@ -7,11 +7,21 @@
 package simd_test
 
 import (
+	"fmt"
+	"os"
 	"reflect"
 	"simd/archsimd"
 	"slices"
 	"testing"
 )
+
+func TestMain(m *testing.M) {
+	if !archsimd.X86.AVX() {
+		fmt.Fprintln(os.Stderr, "Skipping tests: AVX is not available")
+		os.Exit(0)
+	}
+	os.Exit(m.Run())
+}
 
 var sink any
 

--- a/src/simd/archsimd/pkginternal_test.go
+++ b/src/simd/archsimd/pkginternal_test.go
@@ -7,10 +7,20 @@
 package archsimd_test
 
 import (
+	"fmt"
+	"os"
 	"simd/archsimd"
 	"simd/archsimd/internal/test_helpers"
 	"testing"
 )
+
+func TestMain(m *testing.M) {
+	if !archsimd.X86.AVX() {
+		fmt.Fprintln(os.Stderr, "Skipping tests: AVX is not available")
+		os.Exit(0)
+	}
+	os.Exit(m.Run())
+}
 
 func TestConcatSelectedConstant64(t *testing.T) {
 	a := make([]int64, 2)


### PR DESCRIPTION
The simd operations require AVX. If AVX is not available, skip the tests.

Change-Id: I3c384ba07e1e6c2c198dfb27bc84a2e27f825680
Reviewed-on: https://go-review.googlesource.com/c/go/+/729820
LUCI-TryBot-Result: Go LUCI <golang-scoped@luci-project-accounts.iam.gserviceaccount.com>
Reviewed-by: David Chase <drchase@google.com>

This PR will be imported into Gerrit with the title and first
comment (this text) used to generate the subject and body of
the Gerrit change.

**Please ensure you adhere to every item in this list.**

More info can be found at https://github.com/golang/go/wiki/CommitMessage

+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter
+ No Markdown
+ The first PR comment (this one) is wrapped at 76 characters, unless it's
  really needed (ASCII art, table, or long link)
+ If there is a corresponding issue, add either `Fixes #1234` or `Updates #1234`
  (the latter if this is not a complete fix) to this comment
+ If referring to a repo other than `golang/go` you can use the
  `owner/repo#issue_number` syntax: `Fixes golang/tools#1234`
+ We do not use Signed-off-by lines in Go. Please don't add them.
  Our Gerrit server & GitHub bots enforce CLA compliance instead.
+ Delete these instructions once you have read and applied them
